### PR TITLE
Change test to use updated `XCTestCaseProvider` protocol

### DIFF
--- a/test-xctest-package/main.swift
+++ b/test-xctest-package/main.swift
@@ -1,7 +1,7 @@
 import XCTest
 
 class MyXCTest : XCTestCase {
-    var allTests : [(String, () -> ())] {
+    var allTests : [(String, () throws -> ())] {
         return []
     }
 }


### PR DESCRIPTION
Updated swift-integration-tests based on change made in https://github.com/apple/swift-corelibs-xctest/commit/e5c0cb36bc445d0522f7ec28a8342b2681f68666.