### PR TITLE
Revert "[xctest] disable the test due to https://github.com/apple/swift-corelibs-foundation/pull/304"

### DIFF
--- a/test-xctest-package/test-xctest-package.py
+++ b/test-xctest-package/test-xctest-package.py
@@ -1,8 +1,6 @@
 # Trivial test for importing XCTest.
 #
-# https://github.com/apple/swift-corelibs-foundation/pull/304
-# REQUIRES: disabled
-#
+
 # This test doesn't work on Darwin yet, because the XCTest overlay isn't shipped
 # with the package, and can't be found:#
 #   <rdar://problem/23600043> Cannot import XCTest with swift from a downloadable package


### PR DESCRIPTION
Reverts apple/swift-integration-tests#3