### PR TITLE
Python 3 compatibility

### DIFF
--- a/repl/test-repl-glibc.py
+++ b/repl/test-repl-glibc.py
@@ -9,6 +9,8 @@
 # RUN: %{FileCheck} --input-file %t.dir/output.txt %s
 # CHECK: OK
 
+from __future__ import print_function
+
 import pexpect, sys
 
 swift = "swift"
@@ -56,4 +58,4 @@ repl.expect("init")
 # print repl.match.groups()
 # print '--'
 
-print "OK"
+print("OK")


### PR DESCRIPTION
Python 3 seems to require parenthesis around the print function when Python 2 did not. This _should_ work on both. Though admittedly I do not have the means to test it.