### PR TITLE
Disable all tests that rely on swift-build.

### DIFF
--- a/swift-build.py
+++ b/swift-build.py
@@ -1,5 +1,8 @@
 # Trivial test for Swift build.
 #
+# No swift-build in 2.2
+# REQUIRES: disabled
+#
 # Make a sandbox dir.
 # RUN: rm -rf %t.dir
 # RUN: mkdir -p %t.dir/tool

--- a/swift-package-with-spaces.py
+++ b/swift-package-with-spaces.py
@@ -1,5 +1,8 @@
 # Check a package with spaces.
 #
+# No swift-build in 2.2
+# REQUIRES: disabled
+#
 # Make a sandbox dir.
 # RUN: rm -rf %t.dir
 # RUN: mkdir -p %t.dir/more\ spaces/special\ tool

--- a/test-foundation-package/test-foundation-package.py
+++ b/test-foundation-package/test-foundation-package.py
@@ -1,5 +1,9 @@
 # Trivial test for importing Foundation
 #
+#
+# No swift-build in 2.2
+# REQUIRES: disabled
+#
 # 
 # Make a sandbox dir.
 # RUN: rm -rf %t.dir

--- a/test-xctest-package/test-xctest-package.py
+++ b/test-xctest-package/test-xctest-package.py
@@ -1,6 +1,9 @@
 # Trivial test for importing XCTest.
 #
-
+#
+# No swift-build in 2.2
+# REQUIRES: disabled
+#
 # This test doesn't work on Darwin yet, because the XCTest overlay isn't shipped
 # with the package, and can't be found:#
 #   <rdar://problem/23600043> Cannot import XCTest with swift from a downloadable package


### PR DESCRIPTION
swift-build is not included in the 2.3 package.

(cherry picked from commit c497103941f49a7ad834d0e68d4bf9702491fce4)