### PR TITLE
Disable swiftpm lldb test on linux

### DIFF
--- a/test-lldb-with-c-package/test-xctest-package.txt
+++ b/test-lldb-with-c-package/test-xctest-package.txt
@@ -1,5 +1,8 @@
 // Check that we can debug a system module package.
 //
+// FIXME Figure out linux.
+// REQUIRES: platform=Darwin
+//
 // Make a sandbox dir.
 // RUN: rm -rf %t.dir
 // RUN: mkdir -p %t.dir


### PR DESCRIPTION
Need to figure out why lldb doesn't print anything at all on linux