### PR TITLE
Rather than specifying FileCheck, just specify a path to an llvm-buil…

### DIFF
--- a/lit.cfg
+++ b/lit.cfg
@@ -130,20 +130,15 @@ if package_path is None:
 package_path = os.path.abspath(package_path)
 lit_config.note("testing package: %r" % (package_path,))
 
-# Find the path to FileCheck. We just pick any one out of the build directory.
-swift_build_path =  os.path.join(srcroot, "..", "build")
-filecheck_path = lit_config.params.get("filecheck")
-if filecheck_path is None:
-    for variant in os.listdir(swift_build_path):
-        variant_path = os.path.join(swift_build_path, variant)
-        for tree in os.listdir(variant_path):
-            if tree.startswith("llvm-"):
-                path = os.path.join(variant_path, tree, "bin", "FileCheck")
-                if os.path.exists(path):
-                    filecheck_path = path
-                    break
-if filecheck_path is None:
-    lit_config.fatal("unable to locate FileCheck, '--param filecheck=PATH' is required")
+# Get the path to the llvm binary dir. We use tools from this
+# directory (including FileCheck) to test our snapshots. In terms of
+# the actual swift build directory, this is not ./, but ./bin. This is
+# to potentially allow for an installed llvm binary installation to be
+# used when testing.
+llvm_bin_dir = lit_config.params.get("llvm-bin-dir")
+if llvm_bin_dir is None:
+    lit_config.fatal("'--param llvm_bin_dir=PATH' is required")
+filecheck_path = os.path.join(llvm_bin_dir, 'FileCheck')
 
 # Use the default Swift src layout if swiftpm is not provided as a
 # param


### PR DESCRIPTION
…d-dir.

This will allow other tools from llvm to be used to test the snapshot beyond
FileCheck itself.

rdar://39456714