### PR TITLE
Add package_path as a substitution so tests can "poke" at the snapsho…

### DIFF
--- a/lit.cfg
+++ b/lit.cfg
@@ -186,6 +186,7 @@ if not os.path.exists(lldb_path):
         lit_config.fatal("lldb does not exist!")
 
 # Define our supported substitutions.
+config.substitutions.append( ('%{package_path}', package_path) )
 config.substitutions.append( ('%{not}', os.path.join(srcroot, "not")) )
 config.substitutions.append( ('%{lldb}', lldb_path) )
 config.substitutions.append( ('%{swift}', swift_path) )


### PR DESCRIPTION
…t directly.

rdar://39456714