### PR TITLE
Disable SwiftPM tests pending conversion to new manifest API

### DIFF
--- a/swift-build-self-host.py
+++ b/swift-build-self-host.py
@@ -18,7 +18,7 @@
 #
 # RUN: %{FileCheck} --check-prefix CHECK-BUILD-LOG --input-file %t.build-log %s
 #
-# CHECK-BUILD-LOG: Compile Swift Module 'PackageDescription'
+# CHECK-BUILD-LOG: Compile Swift Module 'Build'
 
 # Verify that the build worked.
 #

--- a/swift-build.txt
+++ b/swift-build.txt
@@ -1,5 +1,8 @@
 // Trivial test for Swift build.
 //
+// <rdar://problem/42022436> Convert SwiftPM tests in swift-integration repo to PackageDescription4
+// REQUIRES: disabled
+//
 // Make a sandbox dir.
 // RUN: rm -rf %t.dir
 // RUN: mkdir -p %t.dir/tool

--- a/swift-package-with-spaces.txt
+++ b/swift-package-with-spaces.txt
@@ -1,5 +1,8 @@
 // Check a package with spaces.
 //
+// <rdar://problem/42022436> Convert SwiftPM tests in swift-integration repo to PackageDescription4
+// REQUIRES: disabled
+//
 // Make a sandbox dir.
 // RUN: rm -rf %t.dir
 // RUN: mkdir -p %t.dir/more\ spaces/special\ tool

--- a/test-complex-xctest-package/test-xctest-package.txt
+++ b/test-complex-xctest-package/test-xctest-package.txt
@@ -1,5 +1,8 @@
 // Check if test modules can import Swift modules which depend on C module.
 //
+// <rdar://problem/42022436> Convert SwiftPM tests in swift-integration repo to PackageDescription4
+// REQUIRES: disabled
+//
 // Make a sandbox dir.
 // RUN: rm -rf %t.dir
 // RUN: mkdir -p %t.dir

--- a/test-foundation-package/test-foundation-package.txt
+++ b/test-foundation-package/test-foundation-package.txt
@@ -1,5 +1,7 @@
 // Trivial test for importing Foundation
 //
+// <rdar://problem/42022436> Convert SwiftPM tests in swift-integration repo to PackageDescription4
+// REQUIRES: disabled
 //
 // Make a sandbox dir.
 // RUN: rm -rf %t.dir

--- a/test-xctest-package/test-xctest-package.txt
+++ b/test-xctest-package/test-xctest-package.txt
@@ -1,5 +1,7 @@
 // Trivial test for importing XCTest.
 //
+// <rdar://problem/42022436> Convert SwiftPM tests in swift-integration repo to PackageDescription4
+// REQUIRES: disabled
 //
 // This test doesn't work on Darwin yet, because the XCTest overlay isn't shipped
 // with the package, and can't be found:#


### PR DESCRIPTION
<rdar://problem/42022436> Convert SwiftPM tests in swift-integration repo to PackageDescription4