### PR TITLE
Revert "[REPL] Test RPATH is set correctly on linux."

### DIFF
--- a/lit.cfg
+++ b/lit.cfg
@@ -169,11 +169,6 @@ lldb_path = lit_config.params.get(
     "lldb",
     os.path.join(package_path, "usr", "bin", "lldb"))
 lit_config.note("testing using 'lldb': {}".format(lldb_path))
-
-repl_swift_dummy_path = lit_config.params.get(
-    "repl_swift",
-    os.path.join(package_path, "usr", "bin", "repl_swift"))
-lit_config.note("testing using 'repl_swift': {}".format(repl_swift_dummy_path))
                     
 # Verify they exist.
 if not os.path.exists(swift_path):
@@ -187,15 +182,12 @@ if not os.path.exists(lldb_path):
         lldb_path = subprocess.check_output(["xcrun", "--find", "lldb"]).strip()
     else:
         lit_config.fatal("lldb does not exist!")
-if not os.path.exists(repl_swift_dummy_path):
-    lit_config.fatal("repl_swift does not exist!")
 
 # Define our supported substitutions.
 config.substitutions.append( ('%{package_path}', package_path) )
 config.substitutions.append( ('%{python}', sys.executable) )
 config.substitutions.append( ('%{not}', os.path.join(srcroot, "not")) )
 config.substitutions.append( ('%{lldb}', lldb_path) )
-config.substitutions.append( ('%{repl_swift}', repl_swift_dummy_path) )
 config.substitutions.append( ('%{swift}', swift_path) )
 config.substitutions.append( ('%{swiftc}', swiftc_path) )
 config.substitutions.append( ('%{FileCheck}', filecheck_path) )

--- a/test-rpath-linux-repl/test-rpath-linux-repl.py
+++ b/test-rpath-linux-repl/test-rpath-linux-repl.py
@@ -1,4 +1,0 @@
-# Tests that DT_RPATH is correct for the dummy repl executable on Linux.
-# REQUIRES: platform=Linux
-# RUN: %{readelf} -d %{repl_swift} | %{FileCheck} %s
-# CHECK: {{.*}} RPATH {{.*}}$ORIGIN/../lib/swift/linux


### PR DESCRIPTION
Reverts apple/swift-integration-tests#31

macOS: 
https://ci.swift.org/job/oss-swift-package-osx/2024/console

```
lit.py: /Users/buildnode/jenkins/workspace/oss-swift-package-osx/swift-integration-tests/lit.cfg:191: fatal: repl_swift does not exist!
/Users/buildnode/jenkins/workspace/oss-swift-package-osx/swift/utils/build-script: fatal error: command terminated with a non-zero exit status 2, aborting
/Users/buildnode/jenkins/workspace/oss-swift-package-osx/swift/utils/build-script: fatal error: command terminated with a non-zero exit status 1, aborting
```

Linux: 
https://ci.swift.org/job/oss-swift-package-linux-ubuntu-18_04/63/console

```
AIL: swift-package-tests :: test-rpath-linux-repl/test-rpath-linux-repl.py (9 of 23)
******************** TEST 'swift-package-tests :: test-rpath-linux-repl/test-rpath-linux-repl.py' FAILED ********************
Script:
--
: 'RUN: at line 3';   /home/buildnode/jenkins/workspace/oss-swift-package-linux-ubuntu-18_04/build/buildbot_linux/llvm-linux-x86_64/bin/llvm-readelf -d /home/buildnode/jenkins/workspace/oss-swift-package-linux-ubuntu-18_04/build/buildbot_linux/none-swift_package_sandbox_linux-x86_64/usr/bin/repl_swift | /home/buildnode/jenkins/workspace/oss-swift-package-linux-ubuntu-18_04/build/buildbot_linux/llvm-linux-x86_64/bin/FileCheck /home/buildnode/jenkins/workspace/oss-swift-package-linux-ubuntu-18_04/swift-integration-tests/test-rpath-linux-repl/test-rpath-linux-repl.py
--
Exit Code: 1

Command Output (stdout):
--
$ ":" "RUN: at line 3"
$ "/home/buildnode/jenkins/workspace/oss-swift-package-linux-ubuntu-18_04/build/buildbot_linux/llvm-linux-x86_64/bin/llvm-readelf" "-d" "/home/buildnode/jenkins/workspace/oss-swift-package-linux-ubuntu-18_04/build/buildbot_linux/none-swift_package_sandbox_linux-x86_64/usr/bin/repl_swift"
$ "/home/buildnode/jenkins/workspace/oss-swift-package-linux-ubuntu-18_04/build/buildbot_linux/llvm-linux-x86_64/bin/FileCheck" "/home/buildnode/jenkins/workspace/oss-swift-package-linux-ubuntu-18_04/swift-integration-tests/test-rpath-linux-repl/test-rpath-linux-repl.py"
# command stderr:
/home/buildnode/jenkins/workspace/oss-swift-package-linux-ubuntu-18_04/swift-integration-tests/test-rpath-linux-repl/test-rpath-linux-repl.py:4:10: error: CHECK: expected string not found in input
# CHECK: {{.*}} RPATH {{.*}}$ORIGIN/../lib/swift/linux
         ^
<stdin>:1:1: note: scanning from here
DynamicSection [ (27 entries)
^
<stdin>:6:161: note: possible intended match here
 0x000000000000001d RUNPATH /home/buildnode/jenkins/workspace/oss-swift-package-linux-ubuntu-18_04/build/buildbot_linux/lldb-linux-x86_64/../swift-linux-x86_64/lib/swift/linux:$ORIGIN/../lib/swift/linux:
                                                                                                                                                                ^

error: command failed with exit status: 1

--

********************

```