### PR TITLE
[REPL] Test RPATH is set correctly on linux.

### DIFF
--- a/lit.cfg
+++ b/lit.cfg
@@ -169,6 +169,11 @@ lldb_path = lit_config.params.get(
     "lldb",
     os.path.join(package_path, "usr", "bin", "lldb"))
 lit_config.note("testing using 'lldb': {}".format(lldb_path))
+
+repl_swift_dummy_path = lit_config.params.get(
+    "repl_swift",
+    os.path.join(package_path, "usr", "bin", "repl_swift"))
+lit_config.note("testing using 'repl_swift': {}".format(repl_swift_dummy_path))
                     
 # Verify they exist.
 if not os.path.exists(swift_path):
@@ -182,12 +187,17 @@ if not os.path.exists(lldb_path):
         lldb_path = subprocess.check_output(["xcrun", "--find", "lldb"]).strip()
     else:
         lit_config.fatal("lldb does not exist!")
+if not os.path.exists(repl_swift_dummy_path):
+    if platform.system() == 'Linux':
+        lit_config.fatal("repl_swift does not exist!")
 
 # Define our supported substitutions.
 config.substitutions.append( ('%{package_path}', package_path) )
 config.substitutions.append( ('%{python}', sys.executable) )
 config.substitutions.append( ('%{not}', os.path.join(srcroot, "not")) )
 config.substitutions.append( ('%{lldb}', lldb_path) )
+if platform.system() == 'Linux':
+    config.substitutions.append( ('%{repl_swift}', repl_swift_dummy_path) )
 config.substitutions.append( ('%{swift}', swift_path) )
 config.substitutions.append( ('%{swiftc}', swiftc_path) )
 config.substitutions.append( ('%{FileCheck}', filecheck_path) )

--- a/test-snapshot-binaries/test-rpath-linux-repl.py
+++ b/test-snapshot-binaries/test-rpath-linux-repl.py
@@ -1,0 +1,4 @@
+# Tests that DT_RPATH is correct for the dummy repl executable on Linux.
+# REQUIRES: platform=Linux
+# RUN: %{readelf} -d %{repl_swift} | %{FileCheck} %s
+# CHECK: {{.*}} {{RPATH|RUNPATH}} {{.*}}$ORIGIN/../lib/swift/linux


### PR DESCRIPTION
This recommits the recently reverted commit but with
few modifications:

-> We test for either DT_RPATH or DT_RUNPATH as different
versions of gold emit different (but equivalent) tags.
-> The test is moved to the correct directory (pointed out
by Michael Gottemsmann)
-> The test is limited to run on Linux, as it doesn't make
sense on Darwin.

<rdar://problem/42863249>