### PR TITLE
Print a message if lit detects the swift benchmarks are usable for in…

### DIFF
--- a/lit.cfg
+++ b/lit.cfg
@@ -162,6 +162,7 @@ if swift_benchmarks_path is None:
 if os.path.exists(swift_benchmarks_path):
     config.available_features.add("have-swift-benchmarks")
     config.substitutions.append( ('%{swift_benchmarks_path}', swift_benchmarks_path) )
+    lit_config.note('testing using swift benchmarks at path: {}'.format(swift_benchmarks_path))
     
 # Find the tools we need.
 


### PR DESCRIPTION
…tegration testing.

----

Seems useful for ease of debugging.