### PR TITLE
[benchmark] Add a note that states if we failed to find the swift ben…

### DIFF
--- a/lit.cfg
+++ b/lit.cfg
@@ -163,7 +163,9 @@ if os.path.exists(swift_benchmarks_path):
     config.available_features.add("have-swift-benchmarks")
     config.substitutions.append( ('%{swift_benchmarks_path}', swift_benchmarks_path) )
     lit_config.note('testing using swift benchmarks at path: {}'.format(swift_benchmarks_path))
-    
+else:
+    lit_config.note('Failed to find swift benchmarks, skipping related tests.')
+
 # Find the tools we need.
 
 swift_path = lit_config.params.get(


### PR DESCRIPTION
…chmark suite.

This will make it easier to identify in the CI if we failed to find the swift
benchmark suite.