### PR TITLE
Disable test until SR-9384 is evaluated/fixed.

### DIFF
--- a/test-static-stdlib/test-static-stdlib.test
+++ b/test-static-stdlib/test-static-stdlib.test
@@ -1,4 +1,6 @@
 
+REQUIRES: SR9384
+
 RUN: rm -rf %t
 RUN: mkdir -p %t
 RUN: %{swiftc} -static-stdlib %S/main.swift -o %t/main


### PR DESCRIPTION
I thought this functionality was passing. I just used Foundation and try to statically link Foundation... unhappiness results.