### PR TITLE
[5.0] Cherry-pick 'Update one last place for Compile -> Compiling'

### DIFF
--- a/swift-package-init-lib.md
+++ b/swift-package-init-lib.md
@@ -18,7 +18,7 @@ RUN: %{FileCheck} --check-prefix CHECK-BUILD-LOG --input-file %t.build-log %s
 ```
 
 ```
-CHECK-BUILD-LOG: Compile Swift Module 'Project'
+CHECK-BUILD-LOG: Compiling Swift Module 'Project'
 ```
 
 ## Check the test log.


### PR DESCRIPTION
Swift 5 Package jobs are failing because of this at the moment, e.g.:
- https://ci.swift.org/job/oss-swift-5.0-package-linux-ubuntu-16_04/75/console
- https://ci.swift.org/job/oss-swift-5.0-package-osx/74/console