### PR TITLE
[5.2] Disable test-sourcekit-lsp on Linux

### DIFF
--- a/test-sourcekit-lsp/test-sourcekit-lsp.py
+++ b/test-sourcekit-lsp/test-sourcekit-lsp.py
@@ -3,6 +3,10 @@
 
 # REQUIRES: have-sourcekit-lsp
 
+# Disabled on Linux on swift-5.2-branch due to sporadic failures that were fixed
+# on master in sourcekit-lsp fae2fe85a7b40.
+# REQUIRES: platform=Darwin
+
 # Make a sandbox dir.
 # RUN: rm -rf %t.dir
 # RUN: mkdir -p %t.dir


### PR DESCRIPTION
We get sporadic failures due to incomplete output. They are fixed on
sourcekit-lsp master, but we the fix is not in 5.2 branch. Disable the
test on Linux for now to workaround.

rdar://60159448