### PR TITLE
add a test case for an invalid optimization

### DIFF
--- a/test-foundation-package/test-foundation-networking-fetch.swift
+++ b/test-foundation-package/test-foundation-networking-fetch.swift
@@ -1,0 +1,6 @@
+import Foundation
+import FoundationNetworking
+
+let url = URL(string: "http://swift.org")!
+let data = try! Data(contentsOf: url)
+print(data.underestimatedCount)

--- a/test-foundation-package/test-foundation-networking-fetch.txt
+++ b/test-foundation-package/test-foundation-networking-fetch.txt
@@ -1,0 +1,8 @@
+REQUIRES: platform=Linux
+
+RUN: rm -rf %t
+RUN: mkdir -p %t
+RUN: %{swiftc}  -o %t/test-foundation-networking-fetch %S/test-foundation-networking-fetch.swift
+RUN: %t/test-foundation-networking-fetch | %{FileCheck} %s
+
+CHECK: {{[0-9]+}}


### PR DESCRIPTION
A recent optimization was overly aggressive and resulted in a miscompile
in FoundationNetworking.  Add a test case.