### PR TITLE
Make sure apple/swift#34023, which removes /usr/lib/swift/linux from the RUNPATH of several Swift libraries, stays that way

### DIFF
--- a/test-snapshot-binaries/test-rpath-linux-repl.py
+++ b/test-snapshot-binaries/test-rpath-linux-repl.py
@@ -1,4 +1,0 @@
-# Tests that DT_RPATH is correct for the dummy repl executable on Linux.
-# REQUIRES: platform=Linux
-# RUN: %{readelf} -d %{repl_swift} | %{FileCheck} %s
-# CHECK: {{.*}} {{\(RPATH\)|\(RUNPATH\)}} {{.*}}$ORIGIN/../lib/swift/linux

--- a/test-snapshot-binaries/test-rpath-linux.py
+++ b/test-snapshot-binaries/test-rpath-linux.py
@@ -1,0 +1,29 @@
+# Tests that DT_RPATH is correct for the dummy repl executable on Linux.
+# REQUIRES: platform=Linux
+# RUN: %{readelf} -d %{repl_swift} | %{FileCheck} %s
+# CHECK: {{.*}} {{\(RPATH\)|\(RUNPATH\)}} {{.*}}$ORIGIN/../lib/swift/linux
+#
+# Tests that DT_RUNPATH is correct for the Swift stdlib and other libraries on Linux.
+# RUN: %{readelf} -d %{package_path}/usr/lib/swift/linux/libswiftCore.so | %{FileCheck} --check-prefix CHECK-CORE %s
+# CHECK-CORE-NOT: {{.*}} {{\(RPATH\)|\(RUNPATH\)}} {{.*}}:/usr/lib/swift/linux
+#
+# RUN: %{readelf} -d %{package_path}/usr/lib/libsourcekitdInProc.so | %{FileCheck} --check-prefix CHECK-SK %s
+# CHECK-SK-NOT: {{.*}} {{\(RPATH\)|\(RUNPATH\)}} {{.*}}:/usr/lib/swift/linux
+#
+# RUN: %{readelf} -d %{package_path}/usr/lib/swift/linux/libswiftRemoteMirror.so | %{FileCheck} --check-prefix CHECK-RM %s
+# CHECK-RM-NOT: {{.*}} {{\(RPATH\)|\(RUNPATH\)}} {{.*}}:/usr/lib/swift/linux
+#
+# RUN: %{readelf} -d %{package_path}/usr/lib/swift/linux/libswift_Differentiation.so | %{FileCheck} --check-prefix CHECK-SD %s
+# CHECK-SD-NOT: {{.*}} {{\(RPATH\)|\(RUNPATH\)}} {{.*}}:/usr/lib/swift/linux
+#
+# RUN: %{readelf} -d %{package_path}/usr/lib/swift/linux/lib_InternalSwiftSyntaxParser.so | %{FileCheck} --check-prefix CHECK-SP %s
+# CHECK-SP-NOT: {{.*}} {{\(RPATH\)|\(RUNPATH\)}} {{.*}}:/usr/lib/swift/linux
+#
+# RUN: %{readelf} -d %{package_path}/usr/lib/swift/linux/libswiftGlibc.so | %{FileCheck} --check-prefix CHECK-SG %s
+# CHECK-SG-NOT: {{.*}} {{\(RPATH\)|\(RUNPATH\)}} {{.*}}:/usr/lib/swift/linux
+#
+# RUN: %{readelf} -d %{package_path}/usr/lib/swift/linux/libswiftSwiftOnoneSupport.so | %{FileCheck} --check-prefix CHECK-SON %s
+# CHECK-SON-NOT: {{.*}} {{\(RPATH\)|\(RUNPATH\)}} {{.*}}:/usr/lib/swift/linux
+#
+# RUN: %{readelf} -d %{package_path}/usr/lib/libswiftDemangle.so | %{FileCheck} --check-prefix CHECK-SDE %s
+# CHECK-SDE-NOT: {{.*}} {{\(RPATH\)|\(RUNPATH\)}} {{.*}}:/usr/lib/swift/linux


### PR DESCRIPTION
Recommended by @gottesmm, needs to be tested with that pull.