### PR TITLE
linux_load_commands, test-sourcekit-lsp are python2

### DIFF
--- a/test-snapshot-binaries/linux_load_commands.py
+++ b/test-snapshot-binaries/linux_load_commands.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python2
 
 # REQUIRES: platform=Linux
 # RUN: rm -rf %T && mkdir -p %t

--- a/test-sourcekit-lsp/test-sourcekit-lsp.py
+++ b/test-sourcekit-lsp/test-sourcekit-lsp.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python2
+
 # Canary test for sourcekit-lsp, covering interaction with swiftpm and toolchain
 # language services.
 


### PR DESCRIPTION
contents and build default deviate. as long the contents is python2 let the default interpreter for it be python2 as well. @gottesmm allow me to ping.