### PR TITLE
SR-9384: Revert disabling test-static-stdlib.test

### DIFF
--- a/test-static-stdlib/test-static-stdlib.test
+++ b/test-static-stdlib/test-static-stdlib.test
@@ -1,6 +1,4 @@
-
-REQUIRES: SR9384
-
+REQUIRES: platform=Linux
 RUN: rm -rf %t
 RUN: mkdir -p %t
 RUN: %{swiftc} -static-stdlib %S/main.swift -o %t/main


### PR DESCRIPTION
- Make sure the test is only run on Linux as -static-stdlib doesnt
  work on Apple platforms anymore.