### PR TITLE
Revert "[sk-stress-test] Disable test temporarily rdar://71634533"

### DIFF
--- a/sk-stress-test.txt
+++ b/sk-stress-test.txt
@@ -2,9 +2,6 @@
 //
 // REQUIRES: platform=Darwin
 //
-// FIXME: invocation of sk-stress-test is failing with -4 in CI.
-// REQUIRES: rdar71634533
-//
 // RUN: rm -rf %t.dir
 // RUN: mkdir -p %t.dir
 // RUN: cp %s %t.dir/test.swift


### PR DESCRIPTION
This reverts commit 9a3f0adbbc0fd4d1db9f4095a39c3b421389612c.

https://github.com/apple/swift-stress-tester/pull/141 should fix this issue