### PR TITLE
Propagate XDG_CACHE_HOME to lit tests

### DIFF
--- a/lit.cfg
+++ b/lit.cfg
@@ -91,6 +91,11 @@ if platform.system() == "Darwin":
     config.environment["SDKROOT"] = subprocess.check_output(
         ["xcrun", "--sdk", "macosx", "--show-sdk-path"]).strip()
 
+# XDG_CACHE_HOME can be used to influence the position of the clang
+# module cache for all those tests that do not set that explicitly
+if 'XDG_CACHE_HOME' in os.environ:
+  config.environment['XDG_CACHE_HOME'] = os.environ['XDG_CACHE_HOME']
+
 ###
 
 # Use features like this in lit:


### PR DESCRIPTION
This is another tool we can leverage to configure separate caches for CI
runs in Linux to hopefully reduce the likelihood of module cache
related issues.
Also this will allow us to respect the default values for the
environment we are running in.

As per clang source code, the environment variable only impacts Linux
environments.

This mimicks https://github.com/apple/swift/pull/35588

Addresses rdar://73833137