### PR TITLE
[5.4] Propagate XDG_CACHE_HOME to lit tests

### DIFF
--- a/lit.cfg
+++ b/lit.cfg
@@ -91,6 +91,11 @@ if platform.system() == "Darwin":
     config.environment["SDKROOT"] = subprocess.check_output(
         ["xcrun", "--sdk", "macosx", "--show-sdk-path"]).strip()
 
+# XDG_CACHE_HOME can be used to influence the position of the clang
+# module cache for all those tests that do not set that explicitly
+if 'XDG_CACHE_HOME' in os.environ:
+  config.environment['XDG_CACHE_HOME'] = os.environ['XDG_CACHE_HOME']
+
 ###
 
 # Use features like this in lit:


### PR DESCRIPTION
Explanation: Propagate XDG_CACHE_HOME environment variable to lit tests
in swift-integration-tests, so that the default location of the module
cache can be relocated.
    Cherry picks of existing PRs
        https://github.com/apple/swift-integration-tests/pull/81

Resolves: rdar://74948682

Scope: CI runs for 5.4 jobs

Risk: Low -- the same code is used for main CI runs

(cherry picked from commit 22d72d7617a756c37a45f524e6f5c181b7e81f32)