### PR TITLE
Revert "Disable swift-driver while investigating several test failures"

### DIFF
--- a/lit.cfg
+++ b/lit.cfg
@@ -91,10 +91,6 @@ if platform.system() == "Darwin":
     config.environment["SDKROOT"] = subprocess.check_output(
         ["xcrun", "--sdk", "macosx", "--show-sdk-path"]).strip()
 
-
-# FIXME: use the new driver to run the integration tests. rdar://75547347
-config.environment["SWIFT_USE_OLD_DRIVER"] = 'YES'
-
 # XDG_CACHE_HOME can be used to influence the position of the clang
 # module cache for all those tests that do not set that explicitly
 if 'XDG_CACHE_HOME' in os.environ:


### PR DESCRIPTION
This reverts commit 432c2dd701304b392653274030b84f4d19db0c78.

I can no longer reproduce the failures we were seeing then with recent toolchains so let's go back to using the new driver. 

I suspect https://github.com/apple/swift-driver/pull/581 was the fix. 

Resolves rdar://75547347
