### PR TITLE
Enable sk-stress-test again

### DIFF
--- a/sk-stress-test.txt
+++ b/sk-stress-test.txt
@@ -1,7 +1,6 @@
 // Trivial test for the SourceKit stress tester and compiler wrapper.
 //
 // REQUIRES: platform=Darwin
-// REQUIRES: rdar83727870
 //
 // RUN: rm -rf %t.dir
 // RUN: mkdir -p %t.dir


### PR DESCRIPTION
Reverts apple/swift-integration-tests#89. The underlying issue has been fixed by https://github.com/apple/swift-syntax/pull/318.