### PR TITLE
adapt for 3f9004c19c9b790afa58bc5ae22e9c854d2afed0

### DIFF
--- a/test-snapshot-binaries/linux_load_commands.py
+++ b/test-snapshot-binaries/linux_load_commands.py
@@ -85,7 +85,7 @@ def process_library(args, lib):
     numberOfLinesSeen = 0
 
     print("Visiting lib: {}".format(lib))
-    lines = list(reversed(subprocess.check_output([args.read_elf, "-program-headers", lib], universal_newlines=True).split("\n")[:-1]))
+    lines = list(reversed(subprocess.check_output([args.read_elf, "--program-headers", lib], universal_newlines=True).split("\n")[:-1]))
     p = ParseState()
 
     # Until we finish parsing or run out of lines to parse...


### PR DESCRIPTION
The single dash version of the options have been removed upstream.  This
breaks when testing with the rebranch.  Adjust the script accordingly.