### PR TITLE
Add integration test for Swift-DocC

### DIFF
--- a/lit.cfg
+++ b/lit.cfg
@@ -58,7 +58,7 @@ config.suffixes = [".txt", ".py", ".md", ".test"]
 # excludes: A list of directories to exclude from the testsuite. The 'Inputs'
 # subdirectories contain auxiliary inputs for various tests in their parent
 # directories.
-config.excludes = ['README.md', 'CONTRIBUTING.md', 'Inputs']
+config.excludes = ['README.md', 'CONTRIBUTING.md', 'Inputs', 'DocCTest.docc']
 
 # test_source_root: The root path where tests are located.
 config.test_source_root = os.path.join(srcroot)

--- a/lit.cfg
+++ b/lit.cfg
@@ -196,7 +196,12 @@ lit_config.note("testing using 'repl_swift': {}".format(repl_swift_dummy_path))
 sourcekit_lsp_path = lit_config.params.get(
     "sourcekit-lsp",
     os.path.join(package_path, "usr", "bin", "sourcekit-lsp"))
-                    
+
+docc_path = lit_config.params.get(
+    "docc",
+    os.path.join(package_path, "usr", "bin", "docc"))
+lit_config.note("testing using 'docc': {}".format(docc_path))
+
 # Verify they exist.
 if not os.path.exists(swift_path):
     lit_config.fatal("swift does not exist!")
@@ -219,6 +224,9 @@ if os.path.exists(sourcekit_lsp_path):
 else:
     lit_config.note("'sourcekit-lsp' unavailable, skipping related tests")
 
+if not os.path.exists(docc_path):
+    lit_config.fatal("docc does not exist!")
+
 # Define our supported substitutions.
 config.substitutions.append( ('%{package_path}', package_path) )
 config.substitutions.append( ('%{python}', sys.executable) )
@@ -231,6 +239,7 @@ config.substitutions.append( ('%{swiftc}', swiftc_path) )
 config.substitutions.append( ('%{FileCheck}', filecheck_path) )
 config.substitutions.append( ('%{readelf}', readelf_path) )
 config.substitutions.append( ('%{sourcekit-lsp}', sourcekit_lsp_path) )
+config.substitutions.append( ('%{docc}', docc_path) )
 
 # Add substitutions for swiftpm executables.
 swiftpm_build = lit_config.params.get("swiftpm-build")

--- a/test-swift-docc/DocCTest/Package.swift
+++ b/test-swift-docc/DocCTest/Package.swift
@@ -1,0 +1,28 @@
+// swift-tools-version:5.5
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "DocCTest",
+    products: [
+        // Products define the executables and libraries a package produces, and make them visible to other packages.
+        .library(
+            name: "DocCTest",
+            targets: ["DocCTest"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        .target(
+            name: "DocCTest",
+            dependencies: []),
+        .testTarget(
+            name: "DocCTestTests",
+            dependencies: ["DocCTest"]),
+    ]
+)

--- a/test-swift-docc/DocCTest/README.md
+++ b/test-swift-docc/DocCTest/README.md
@@ -1,0 +1,3 @@
+# DocCTest
+
+This is a minimal test package to verify Swift-DocC integration.

--- a/test-swift-docc/DocCTest/Sources/DocCTest/DocCTest.docc/Documentation.md
+++ b/test-swift-docc/DocCTest/Sources/DocCTest/DocCTest.docc/Documentation.md
@@ -1,0 +1,13 @@
+# ``DocCTest``
+
+This is a summary
+
+## Overview
+
+This is an overview
+
+## Topics
+
+### This is a group
+
+- <doc:DocCTest>

--- a/test-swift-docc/DocCTest/Sources/DocCTest/DocCTest.docc/Info.plist
+++ b/test-swift-docc/DocCTest/Sources/DocCTest/DocCTest.docc/Info.plist
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CDDefaultCodeListingLanguage</key>
+	<string>swift</string>
+	<key>CFBundleName</key>
+	<string>DocCTest</string>
+	<key>CFBundleDisplayName</key>
+	<string>DocCTest</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.apple.DocCTest</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleIconFile</key>
+	<string>DocumentationIcon</string>
+	<key>CFBundleIconName</key>
+	<string>DocumentationIcon</string>
+	<key>CFBundlePackageType</key>
+	<string>DOCS</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.1.0</string>
+	<key>CFBundleVersion</key>
+	<string>0.1.0</string>
+	<key>CDAppleDefaultAvailability</key>
+	<dict>
+		<key>DocCTest</key>
+		<array>
+			<dict>
+				<key>name</key>
+				<string>Mac Catalyst</string>
+				<key>version</key>
+				<string>13.0</string>
+			</dict>
+			<dict>
+				<key>name</key>
+				<string>iOS</string>
+				<key>version</key>
+				<string>13.0</string>
+			</dict>
+			<dict>
+				<key>name</key>
+				<string>tvOS</string>
+				<key>version</key>
+				<string>13.0</string>
+			</dict>
+			<dict>
+				<key>name</key>
+				<string>watchOS</string>
+				<key>version</key>
+				<string>6.0</string>
+			</dict>
+			<dict>
+				<key>name</key>
+				<string>macOS</string>
+				<key>version</key>
+				<string>10.15</string>
+			</dict>
+		</array>
+	</dict>
+</dict>
+</plist>

--- a/test-swift-docc/DocCTest/Sources/DocCTest/DocCTest.swift
+++ b/test-swift-docc/DocCTest/Sources/DocCTest/DocCTest.swift
@@ -1,0 +1,15 @@
+public struct DocCTest {
+    public private(set) var text = "Hello, World!"
+    
+    public var variable: Int
+
+    public init() {
+        variable = 1
+    }
+    
+    /// This is foo
+    /// - Returns: foo returns 0
+    public func foo() -> Int {
+        return 0
+    }
+}

--- a/test-swift-docc/DocCTest/Tests/DocCTestTests/DocCTestTests.swift
+++ b/test-swift-docc/DocCTest/Tests/DocCTestTests/DocCTestTests.swift
@@ -1,0 +1,11 @@
+import XCTest
+@testable import DocCTest
+
+final class DocCTestTests: XCTestCase {
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct
+        // results.
+        XCTAssertEqual(DocCTest().text, "Hello, World!")
+    }
+}

--- a/test-swift-docc/test-swift-docc.txt
+++ b/test-swift-docc/test-swift-docc.txt
@@ -1,0 +1,5 @@
+// Check Swift-DocC can compile and preview documentation.
+//
+// RNU: rm -rf %S/Output
+// RUN: %{docc} convert %S/DocCTest/Sources/DocCTest/DocCTest.docc --output-path %S/Output
+// RUN: ls %S/Output


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://79454450

## Summary
This PR is adding an integration test for `docc convert`.
It runs docc convert on a test project with basic documentation and checks that the command runs to completion.