### PR TITLE
Fix package path for non-/usr builds

### DIFF
--- a/lit.cfg
+++ b/lit.cfg
@@ -175,31 +175,31 @@ else:
 
 swift_path = lit_config.params.get(
     "swift",
-    os.path.join(package_path, "usr", "bin", "swift"))
+    os.path.join(package_path, "bin", "swift"))
 lit_config.note("testing using 'swift': %r" % (swift_path,))
 
 swiftc_path = lit_config.params.get(
     "swiftc",
-    os.path.join(package_path, "usr", "bin", "swiftc"))
+    os.path.join(package_path, "bin", "swiftc"))
 lit_config.note("testing using 'swiftc': %r" % (swiftc_path,))
 
 lldb_path = lit_config.params.get(
     "lldb",
-    os.path.join(package_path, "usr", "bin", "lldb"))
+    os.path.join(package_path, "bin", "lldb"))
 lit_config.note("testing using 'lldb': {}".format(lldb_path))
 
 repl_swift_dummy_path = lit_config.params.get(
     "repl_swift",
-    os.path.join(package_path, "usr", "bin", "repl_swift"))
+    os.path.join(package_path, "bin", "repl_swift"))
 lit_config.note("testing using 'repl_swift': {}".format(repl_swift_dummy_path))
 
 sourcekit_lsp_path = lit_config.params.get(
     "sourcekit-lsp",
-    os.path.join(package_path, "usr", "bin", "sourcekit-lsp"))
+    os.path.join(package_path, "bin", "sourcekit-lsp"))
 
 docc_path = lit_config.params.get(
     "docc",
-    os.path.join(package_path, "usr", "bin", "docc"))
+    os.path.join(package_path, "bin", "docc"))
 lit_config.note("testing using 'docc': {}".format(docc_path))
 
 # Verify they exist.

--- a/test-snapshot-binaries/test-rpath-linux.py
+++ b/test-snapshot-binaries/test-rpath-linux.py
@@ -4,26 +4,26 @@
 # CHECK: {{.*}} {{\(RPATH\)|\(RUNPATH\)}} {{.*}}$ORIGIN/../lib/swift/linux
 #
 # Tests that DT_RUNPATH is correct for the Swift stdlib and other libraries on Linux.
-# RUN: %{readelf} -d %{package_path}/usr/lib/swift/linux/libswiftCore.so | %{FileCheck} --check-prefix CHECK-CORE %s
+# RUN: %{readelf} -d %{package_path}/lib/swift/linux/libswiftCore.so | %{FileCheck} --check-prefix CHECK-CORE %s
 # CHECK-CORE-NOT: {{.*}} {{\(RPATH\)|\(RUNPATH\)}} {{.*}}:/usr/lib/swift/linux
 #
-# RUN: %{readelf} -d %{package_path}/usr/lib/libsourcekitdInProc.so | %{FileCheck} --check-prefix CHECK-SK %s
+# RUN: %{readelf} -d %{package_path}/lib/libsourcekitdInProc.so | %{FileCheck} --check-prefix CHECK-SK %s
 # CHECK-SK-NOT: {{.*}} {{\(RPATH\)|\(RUNPATH\)}} {{.*}}:/usr/lib/swift/linux
 #
-# RUN: %{readelf} -d %{package_path}/usr/lib/swift/linux/libswiftRemoteMirror.so | %{FileCheck} --check-prefix CHECK-RM %s
+# RUN: %{readelf} -d %{package_path}/lib/swift/linux/libswiftRemoteMirror.so | %{FileCheck} --check-prefix CHECK-RM %s
 # CHECK-RM-NOT: {{.*}} {{\(RPATH\)|\(RUNPATH\)}} {{.*}}:/usr/lib/swift/linux
 #
-# RUN: %{readelf} -d %{package_path}/usr/lib/swift/linux/libswift_Differentiation.so | %{FileCheck} --check-prefix CHECK-SD %s
+# RUN: %{readelf} -d %{package_path}/lib/swift/linux/libswift_Differentiation.so | %{FileCheck} --check-prefix CHECK-SD %s
 # CHECK-SD-NOT: {{.*}} {{\(RPATH\)|\(RUNPATH\)}} {{.*}}:/usr/lib/swift/linux
 #
-# RUN: %{readelf} -d %{package_path}/usr/lib/swift/linux/lib_InternalSwiftSyntaxParser.so | %{FileCheck} --check-prefix CHECK-SP %s
+# RUN: %{readelf} -d %{package_path}/lib/swift/linux/lib_InternalSwiftSyntaxParser.so | %{FileCheck} --check-prefix CHECK-SP %s
 # CHECK-SP-NOT: {{.*}} {{\(RPATH\)|\(RUNPATH\)}} {{.*}}:/usr/lib/swift/linux
 #
-# RUN: %{readelf} -d %{package_path}/usr/lib/swift/linux/libswiftGlibc.so | %{FileCheck} --check-prefix CHECK-SG %s
+# RUN: %{readelf} -d %{package_path}/lib/swift/linux/libswiftGlibc.so | %{FileCheck} --check-prefix CHECK-SG %s
 # CHECK-SG-NOT: {{.*}} {{\(RPATH\)|\(RUNPATH\)}} {{.*}}:/usr/lib/swift/linux
 #
-# RUN: %{readelf} -d %{package_path}/usr/lib/swift/linux/libswiftSwiftOnoneSupport.so | %{FileCheck} --check-prefix CHECK-SON %s
+# RUN: %{readelf} -d %{package_path}/lib/swift/linux/libswiftSwiftOnoneSupport.so | %{FileCheck} --check-prefix CHECK-SON %s
 # CHECK-SON-NOT: {{.*}} {{\(RPATH\)|\(RUNPATH\)}} {{.*}}:/usr/lib/swift/linux
 #
-# RUN: %{readelf} -d %{package_path}/usr/lib/libswiftDemangle.so | %{FileCheck} --check-prefix CHECK-SDE %s
+# RUN: %{readelf} -d %{package_path}/lib/libswiftDemangle.so | %{FileCheck} --check-prefix CHECK-SDE %s
 # CHECK-SDE-NOT: {{.*}} {{\(RPATH\)|\(RUNPATH\)}} {{.*}}:/usr/lib/swift/linux


### PR DESCRIPTION
This depends on another change to the build script in the swift repo to pass in the correct
package path.

Need another pair of eyes on `test-rpath-linux.py` on the `CHECK-*-NOT` clauses; test passes as is, but this most likely needs to be changed as well.