### PR TITLE
[5.7] Disable test-swift-docc.txt to unblock PR testing

### DIFF
--- a/test-swift-docc/test-swift-docc.txt
+++ b/test-swift-docc/test-swift-docc.txt
@@ -3,3 +3,6 @@
 // RNU: rm -rf %S/Output
 // RUN: %{docc} convert %S/DocCTest/Sources/DocCTest/DocCTest.docc --output-path %S/Output
 // RUN: ls %S/Output
+
+// REQUIRES: rdar91638258
+


### PR DESCRIPTION
- **Rationale:** Disables the Swift-DocC integration test to unblock Swift CI targeting Swift 5.7.
- **Risk:** Low.
- **Risk Detail:** Disables a test.
- **Reward:** High
- **Reward Details:** Unblocks CI testing in the Swift repo. Example failure: https://github.com/apple/swift/pull/42356. ([Swift-CI Link](https://ci.swift.org/job/swift-PR-Linux/1198/console))
- **Original PR:** #98
- **Issue:** rdar://91638258
- **Code Reviewed By:** N/A
- **Testing Details:** Existing tests continue to pass.