### PR TITLE
Communicate with sourcekit-lsp using UTF-8

### DIFF
--- a/test-sourcekit-lsp/test-sourcekit-lsp.py
+++ b/test-sourcekit-lsp/test-sourcekit-lsp.py
@@ -136,7 +136,7 @@ def main():
     print('==== OUTPUT ====')
 
     skargs = [args.sourcekit_lsp, '--sync', '-Xclangd', '-sync']
-    p = subprocess.Popen(skargs, stdin=subprocess.PIPE, stdout=subprocess.PIPE, universal_newlines=True)
+    p = subprocess.Popen(skargs, stdin=subprocess.PIPE, stdout=subprocess.PIPE, universal_newlines=True, encoding='utf-8')
     out, _ = p.communicate(lsp.script)
     print(out)
     print('')


### PR DESCRIPTION
This is my best guess to fix the failure in https://ci.swift.org/view/Swift%20rebranch/job/oss-swift-rebranch-package-ubuntu-18_04/965.

In either case, I don’t think changing the encoding to UTF-8 hurts.