### PR TITLE
[LSP] Print LSP output as ASCII

### DIFF
--- a/test-sourcekit-lsp/test-sourcekit-lsp.py
+++ b/test-sourcekit-lsp/test-sourcekit-lsp.py
@@ -136,9 +136,9 @@ def main():
     print('==== OUTPUT ====')
 
     skargs = [args.sourcekit_lsp, '--sync', '-Xclangd', '-sync']
-    p = subprocess.Popen(skargs, stdin=subprocess.PIPE, stdout=subprocess.PIPE, universal_newlines=True, encoding='utf-8')
+    p = subprocess.Popen(skargs, stdin=subprocess.PIPE, stdout=subprocess.PIPE, encoding='utf-8')
     out, _ = p.communicate(lsp.script)
-    print(out)
+    print(out.encode(encoding='ascii', errors='replace')
     print('')
 
     if p.returncode == 0:


### PR DESCRIPTION
`sys.stdout` seems to be `ascii` on some configurations, eg. Jenkins. When the string has UTF8 characters, this results in:
```
UnicodeEncodeError: 'ascii' codec can't encode character...
```

The output here is really just for debugging test failures, so just encode the string as ASCII and output that instead.

Resolves rdar://105608805.