### PR TITLE
Update tests for new swiftpm templates

### DIFF
--- a/swift-package-init-tool.md
+++ b/swift-package-init-tool.md
@@ -1,13 +1,12 @@
-# Test `swift package init` (executable)
+# Test `swift package init` (tool)
 
-## Create a new package with an executable target.
+## Create a new package with a tool target.
 
 ```
 RUN: rm -rf %t.dir
 RUN: mkdir -p %t.dir/Project
-RUN: %{swift-package} --package-path %t.dir/Project init --type executable
+RUN: %{swift-package} --package-path %t.dir/Project init --type tool
 RUN: rm -rf %t.dir/Project/Sources/*
-RUN: echo "print(\"Hello, World!\")" >%t.dir/Project/Sources/main.swift
 RUN: %{swift-build} --package-path %t.dir/Project 2>&1 | tee %t.build-log
 ```
 

--- a/swift-run.md
+++ b/swift-run.md
@@ -6,8 +6,8 @@
 RUN: rm -rf %t.dir
 RUN: mkdir -p %t.dir/secho
 RUN: %{swift-package} --package-path %t.dir/secho init --type executable
-RUN: rm -rf %t.dir/secho/Sources/secho/*
-RUN: echo "import Foundation; print(CommandLine.arguments.dropFirst().joined(separator: \" \"))" >%t.dir/secho/Sources/secho/main.swift
+RUN: rm -rf %t.dir/secho/Sources/*
+RUN: echo "import Foundation; print(CommandLine.arguments.dropFirst().joined(separator: \" \"))" >%t.dir/secho/Sources/main.swift
 RUN: %{swift-run} --package-path %t.dir/secho secho 1 "two" 2>&1 | tee %t.run-log
 ```
 


### PR DESCRIPTION
- Update exec and run tests to expect sources in `./Sources` instead of `./Sources/$TARGET`
- Add -tool variant of init tests

rdar://105701394