### PR TITLE
Make sure that no shared libraries or executables on linux ship with a /home runpath from the build host again

### DIFF
--- a/test-snapshot-binaries/test-rpath-linux.py
+++ b/test-snapshot-binaries/test-rpath-linux.py
@@ -38,4 +38,10 @@
 # CHECK-SDE-NOT: {{.*}} {{\(RPATH\)|\(RUNPATH\)}} {{.*}}:/usr/lib/swift/linux
 #
 # RUN: %{readelf} -d %{package_path}/usr/lib/liblldb.so | %{FileCheck} --check-prefix CHECK-LLDB %s
-# CHECK-LLDB: {{.*}} {{\(RPATH\)|\(RUNPATH\)}} {{.*}}$ORIGIN/../lib/swift/linux
+# CHECK-LLDB: {{.*}} {{\(RPATH\)|\(RUNPATH\)}} {{.*}}$ORIGIN/swift/linux
+#
+# RUN: find %{package_path} -name "lib*\.so" | xargs %{readelf} -d | %{FileCheck} --check-prefix CHECK-LIB %s
+# CHECK-LIB-NOT: {{.*}} {{\(RPATH\)|\(RUNPATH\)}} {{.*}}/home/
+#
+# RUN: find %{package_path}/usr/bin -type f | grep -Ev "\.py|\.txt|\.sh" | xargs %{readelf} -d | %{FileCheck} --check-prefix CHECK-BIN %s
+# CHECK-BIN-NOT: {{.*}} {{\(RPATH\)|\(RUNPATH\)}} {{.*}}/home/


### PR DESCRIPTION
This will depend on getting apple/llvm-project#6456 and apple/swift#64365 in first, and make sure this doesn't regress again.

@shahmishal, would appreciate your help in getting these three pulls in cleaning these runpath issues up before the 5.9 branch.