### PR TITLE
[5.9] Re-enable `test-static-stdlib.test`

### DIFF
--- a/test-static-stdlib/test-static-stdlib.test
+++ b/test-static-stdlib/test-static-stdlib.test
@@ -1,5 +1,4 @@
-
-REQUIRES: SR9384
+REQUIRES: platform=Linux
 
 RUN: rm -rf %t
 RUN: mkdir -p %t


### PR DESCRIPTION
This test was disabled for a while, which led to static linking regressions on Linux. It should be re-enabled for us to make sure that this feature works as intended.