### PR TITLE
Set PYTHONIOENCODING for all lit tests

### DIFF
--- a/lit.cfg
+++ b/lit.cfg
@@ -96,6 +96,9 @@ if platform.system() == "Darwin":
 if 'XDG_CACHE_HOME' in os.environ:
   config.environment['XDG_CACHE_HOME'] = os.environ['XDG_CACHE_HOME']
 
+if sys.version_info[0] >= 3:
+    config.environment['PYTHONIOENCODING'] = 'UTF8'
+
 ###
 
 # Use features like this in lit:

--- a/test-sourcekit-lsp/test-sourcekit-lsp.py
+++ b/test-sourcekit-lsp/test-sourcekit-lsp.py
@@ -138,7 +138,7 @@ def main():
     skargs = [args.sourcekit_lsp, '--sync', '-Xclangd', '-sync']
     p = subprocess.Popen(skargs, stdin=subprocess.PIPE, stdout=subprocess.PIPE, encoding='utf-8')
     out, _ = p.communicate(lsp.script)
-    print(out.encode(encoding='ascii', errors='replace'))
+    print(out)
     print('')
 
     if p.returncode == 0:


### PR DESCRIPTION
Rather than the one-off hack in `test-sourcekit-lsp.py`, just set the IO encoding to UTF8 for all tests.