### PR TITLE
Re-enable sourcekit-lsp integration test

### DIFF
--- a/test-sourcekit-lsp/test-sourcekit-lsp.py
+++ b/test-sourcekit-lsp/test-sourcekit-lsp.py
@@ -15,8 +15,6 @@
 # RUN: %{python} -u %s %{sourcekit-lsp} %t.dir/pkg 2>&1 | tee %t.run-log
 # RUN: %{FileCheck} --input-file %t.run-log %s
 
-# REQUIRES: rdar119243893
-
 import argparse
 import json
 import os


### PR DESCRIPTION
The underlying issue of rdar://119243893 has been fixed by https://github.com/apple/sourcekit-lsp/pull/989