### PR TITLE
Re-enable sourcekit-lsp integration test

### DIFF
--- a/test-sourcekit-lsp/test-sourcekit-lsp.py
+++ b/test-sourcekit-lsp/test-sourcekit-lsp.py
@@ -2,7 +2,6 @@
 # language services.
 
 # REQUIRES: have-sourcekit-lsp
-# REQUIRES: rdar123765692
 
 # Make a sandbox dir.
 # RUN: rm -rf %t.dir


### PR DESCRIPTION
I believe the underlying issue was fixed in https://github.com/apple/swift-package-manager/pull/7379. We can’t tell if it does fix the issue for sure because the failure didn’t re-produce in PR testing. Let’s re-enable it and see if the post-merge job still passes.