### PR TITLE
Skip lldb cpython as well

### DIFF
--- a/test-snapshot-binaries/linux_load_commands.py
+++ b/test-snapshot-binaries/linux_load_commands.py
@@ -158,7 +158,10 @@ def main():
           # When linking the swiftCompilerModules to lldb, the text segment
           # gets RWE for some reason.
           # TODO: remove this workaround once rdar://87078244 is fixed
-          if "liblldb.so" in l:
+          #
+          # Additionally th cpython lldb library also has this too
+          # TODO: remove that workaround once rdar://124693792 is fixed
+          if "liblldb.so" in l or "_lldb.cpython" in l:
                 continue
 
           process_library(args, l)


### PR DESCRIPTION
This should disable the checking for lldb's cpython library for the writable bit set for the load address. Since that is a debugging library the risk is relatively low that it would pose any real issue.

Resolves:
rdar://124711430