### PR TITLE
Temporarily disable failing SourceKit LSP test

### DIFF
--- a/test-sourcekit-lsp/test-sourcekit-lsp.py
+++ b/test-sourcekit-lsp/test-sourcekit-lsp.py
@@ -2,6 +2,8 @@
 # language services.
 
 # REQUIRES: have-sourcekit-lsp
+# rdar://125139888
+# REQUIRES: platform=Darwin
 
 # Make a sandbox dir.
 # RUN: rm -rf %t.dir


### PR DESCRIPTION
This is blocking PR testing, disable while we investigate.