### PR TITLE
Test updates for SwiftPM --build-system swiftbuild

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 *~
 *.pyc
-
+.DS_Store

--- a/swift-build.txt
+++ b/swift-build.txt
@@ -16,8 +16,9 @@
 //
 // Verify that the tool exists and works.
 //
-// RUN: test -x %t.dir/tool/.build/debug/tool
-// RUN: %t.dir/tool/.build/debug/tool > %t.out
+// RUN: %{swift-build} --package-path %t.dir/tool --show-bin-path > %t.bin-path
+// RUN: sed 's|$|/tool|' %t.bin-path | xargs test -x
+// RUN: sed 's|$|/tool|' %t.bin-path | xargs sh -c '"$1" > %t.out' --
 // RUN: %{FileCheck} --check-prefix CHECK-TOOL-OUTPUT --input-file %t.out %s
 //
 // CHECK-TOOL-OUTPUT: HI

--- a/swift-package-init-exec.md
+++ b/swift-package-init-exec.md
@@ -18,15 +18,15 @@ RUN: %{FileCheck} --check-prefix CHECK-BUILD-LOG --input-file %t.build-log %s
 ```
 
 ```
-CHECK-BUILD-LOG: Compiling {{.*}}Project{{.*}}
-CHECK-BUILD-LOG: Linking {{.*}}Project
+CHECK-BUILD-LOG: Build complete!
 ```
 
 ## Verify that the tool was built and works.
 
 ```
-RUN: test -x %t.dir/Project/.build/debug/Project
-RUN: %t.dir/Project/.build/debug/Project > %t.out
+RUN: %{swift-build} --package-path %t.dir/Project --show-bin-path > %t.bin-path
+RUN: sed 's|$|/Project|' %t.bin-path | xargs test -x
+RUN: sed 's|$|/Project|' %t.bin-path | xargs sh -c '"$1" > %t.out' --
 RUN: %{FileCheck} --check-prefix CHECK-TOOL-OUTPUT --input-file %t.out %s
 ```
 

--- a/swift-package-init-lib.md
+++ b/swift-package-init-lib.md
@@ -19,7 +19,7 @@ RUN: %{FileCheck} --check-prefix CHECK-BUILD-LOG --input-file %t.build-log %s
 ```
 
 ```
-CHECK-BUILD-LOG: Compiling {{.*}}Project{{.*}}
+CHECK-BUILD-LOG: Build complete!
 ```
 
 ## Check the XCTest log.
@@ -29,7 +29,7 @@ RUN: %{FileCheck} --check-prefix CHECK-XCTEST-LOG --input-file %t.xctest-log %s
 ```
 
 ```
-CHECK-XCTEST-LOG: Compiling {{.*}}ProjectTests{{.*}}
+CHECK-XCTEST-LOG: Build complete!
 CHECK-XCTEST-LOG: Test Suite 'All tests' passed
 CHECK-XCTEST-LOG-NEXT: Executed 1 test
 ```

--- a/swift-package-with-spaces.txt
+++ b/swift-package-with-spaces.txt
@@ -13,12 +13,13 @@
 //
 // RUN: %{FileCheck} --check-prefix CHECK-BUILD-LOG --input-file %t.build-log %s
 //
-// CHECK-BUILD-LOG: swiftc{{.*}} -module-name special_tool {{.*}} '@{{.*}}/.build/{{[^/]+}}/debug/special_tool.build/sources'
+// CHECK-BUILD-LOG: -module-name special_tool
 //
 // Verify that the tool exists and works.
 //
-// RUN: test -x %t.dir/more\ spaces/special\ tool/.build/debug/special\ tool
-// RUN: %t.dir/more\ spaces/special\ tool/.build/debug/special\ tool > %t.out
+// RUN: %{swift-build} --package-path %t.dir/more\ spaces/special\ tool --show-bin-path > %t.bin-path
+// RUN: sed 's|.*|"&/special tool"|' %t.bin-path | xargs test -x
+// RUN: sed 's|.*|"&/special tool"|' %t.bin-path | xargs sh -c '"$1" > %t.out' --
 // RUN: %{FileCheck} --check-prefix CHECK-TOOL-OUTPUT --input-file %t.out %s
 //
 // CHECK-TOOL-OUTPUT: HI

--- a/swift-run.md
+++ b/swift-run.md
@@ -18,7 +18,6 @@ RUN: %{FileCheck} --check-prefix CHECK-BUILD-LOG --input-file %t.run-log %s
 ```
 
 ```
-CHECK-BUILD-LOG: Compiling {{.*}}secho{{.*}}
-CHECK-BUILD-LOG: Linking {{.*}}secho
+CHECK-BUILD-LOG: Build {{.*}}complete!
 CHECK-BUILD-LOG: 1 two
 ```

--- a/test-codecov-package/test-codecov-package.txt
+++ b/test-codecov-package/test-codecov-package.txt
@@ -14,6 +14,7 @@
 //
 // Check the exported codecov file.
 //
-// RUN: %{FileCheck} --check-prefix CHECK-CODECOV-JSON --input-file %t.dir/foo/.build/debug/codecov/foo.json %s
+// RUN: %{swift} test --package-path %t.dir/foo --show-codecov-path > %t.codecov-path
+// RUN: sed 's|^|--input-file |' %t.codecov-path | xargs %{FileCheck} --check-prefix CHECK-CODECOV-JSON %s
 //
 // CHECK-CODECOV-JSON: llvm.coverage.json.export

--- a/test-complex-xctest-package/test-xctest-package.txt
+++ b/test-complex-xctest-package/test-xctest-package.txt
@@ -10,6 +10,5 @@
 //
 // RUN: %{FileCheck} --check-prefix CHECK-BUILD-LOG --input-file %t.build-log %s
 //
-// CHECK-BUILD-LOG: swiftc{{.*}} -module-name SwiftCMixedPackageTests
 // CHECK-BUILD-LOG: testSwiftyFoo{{.*}} passed
 // CHECK-BUILD-LOG: 'SwiftyTests' passed

--- a/test-foundation-package/test-foundation-package.txt
+++ b/test-foundation-package/test-foundation-package.txt
@@ -16,8 +16,9 @@
 //
 // Verify that the tool exists and works.
 //
-// RUN: test -x %t.dir/tool/.build/debug/tool
-// RUN: %t.dir/tool/.build/debug/tool > %t.out
+// RUN: %{swift-build} --package-path %t.dir/tool --show-bin-path > %t.bin-path
+// RUN: sed 's|$|/tool|' %t.bin-path | xargs test -x
+// RUN: sed 's|$|/tool|' %t.bin-path | xargs sh -c '"$1" > %t.out' --
 // RUN: %{FileCheck} --check-prefix CHECK-TOOL-OUTPUT --input-file %t.out %s
 //
 // CHECK-TOOL-OUTPUT: Printing URL

--- a/test-snapshot-binaries/test-rpath-linux.py
+++ b/test-snapshot-binaries/test-rpath-linux.py
@@ -40,10 +40,10 @@
 # RUN: %{readelf} -d %{package_path}/usr/lib/liblldb.so | %{FileCheck} --check-prefix CHECK-LLDB %s
 # CHECK-LLDB: {{.*}} {{\(RPATH\)|\(RUNPATH\)}} {{.*}}$ORIGIN/../lib/swift/linux
 #
-# RUN: find %{package_path} -name "lib*\.so" | xargs %{readelf} -d | %{FileCheck} --check-prefix CHECK-LIB %s
+# RUN: sh -c 'find %{package_path} -name "lib*\.so" | while read f; do %{readelf} -d "$f" 2>/dev/null | sed "s|^|$f: |"; done' | %{FileCheck} --check-prefix CHECK-LIB %s
 # CHECK-LIB-NOT: {{.*}} {{\(RPATH\)|\(RUNPATH\)}} {{.*}}/home/
 # CHECK-LIB-NOT: {{.*}} {{\(RPATH\)|\(RUNPATH\)}} {{.*}}/opt/
 #
-# RUN: find %{package_path}/usr/bin -type f | grep -Ev "\.py|\.txt|\.sh|\.cfg" | xargs %{readelf} -d | %{FileCheck} --check-prefix CHECK-BIN %s
+# RUN: sh -c 'find %{package_path}/usr/bin -type f | grep -Ev "\.py|\.txt|\.sh|\.cfg" | while read f; do %{readelf} -d "$f" 2>/dev/null | sed "s|^|$f: |"; done' | %{FileCheck} --check-prefix CHECK-BIN %s
 # CHECK-BIN-NOT: {{.*}} {{\(RPATH\)|\(RUNPATH\)}} {{.*}}/home/
 # CHECK-BIN-NOT: {{.*}} {{\(RPATH\)|\(RUNPATH\)}} {{.*}}/opt/

--- a/test-swift-testing-package/test-swift-testing-package.txt
+++ b/test-swift-testing-package/test-swift-testing-package.txt
@@ -16,10 +16,9 @@
 //
 // CHECK-BUILD-LOG: swiftc{{.*}} -module-name tool
 //
-// Verify that the tool exists and works.
+// Verify that the tests can be run.
 //
-// RUN: test -x %t.dir/tool/.build/debug/toolPackageTests.xctest
-// RUN: %t.dir/tool/.build/debug/toolPackageTests.xctest --testing-library swift-testing > %t.out
+// RUN: %{swift-test} --package-path %t.dir/tool --enable-swift-testing --disable-xctest > %t.out 2>&1
 // RUN: %{FileCheck} --check-prefix CHECK-TOOL-OUTPUT --input-file %t.out %s
 //
 // CHECK-TOOL-OUTPUT: HI

--- a/test-xctest-package/test-xctest-package.txt
+++ b/test-xctest-package/test-xctest-package.txt
@@ -14,12 +14,13 @@
 //
 // RUN: %{FileCheck} --check-prefix CHECK-BUILD-LOG --input-file %t.build-log %s
 //
-// CHECK-BUILD-LOG: swiftc{{.*}} -module-name tool
+// CHECK-BUILD-LOG: -module-name tool
 //
 // Verify that the tool exists and works.
 //
-// RUN: test -x %t.dir/tool/.build/debug/tool
-// RUN: %t.dir/tool/.build/debug/tool > %t.out
+// RUN: %{swift-build} --package-path %t.dir/tool --show-bin-path > %t.bin-path
+// RUN: sed 's|$|/tool|' %t.bin-path | xargs test -x
+// RUN: sed 's|$|/tool|' %t.bin-path | xargs sh -c '"$1" > %t.out' --
 // RUN: %{FileCheck} --check-prefix CHECK-TOOL-OUTPUT --input-file %t.out %s
 //
 // CHECK-TOOL-OUTPUT: HI


### PR DESCRIPTION
- Consistently use --show-bin-path to find built binaries instead of hardcoding paths
- Loosen some expectations which looked for overly specific build log output

This ensures the tests are compatible with the old and new build systems without meaningfully changing what they cover